### PR TITLE
fix(gitignore): removed audit-data folder from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
-# audit files
-/audit-data
-
 # dependencies
 /node_modules
 /.pnp


### PR DESCRIPTION
The `audit-data` folder was being ignored by git, which made saving/committing local reports impossible.