### PR TITLE
refactor(accounts): revises how audits reference account data

### DIFF
--- a/lumberjack.types.ts
+++ b/lumberjack.types.ts
@@ -1,4 +1,5 @@
 import { ImpactValue, Result, NodeResult } from 'axe-core'
+import { Page } from 'puppeteer'
 
 // Client Types
 
@@ -35,11 +36,15 @@ export type SummaryReport = {
 // CLI Utility Types
 
 export type AppConfig = {
+  accounts?: {
+    default: AccountConfig
+    [key: string]: AccountConfig 
+  }
   errors: {
     content: string[]
     featureId: string
   }
-  login: {
+  login?: {
     fields?: {
       // Identifiers for each login form field
       username?: string


### PR DESCRIPTION
**Changes introduced:**

- Converts runAxeOnPath to use object for params, adds type, makes account optional
- Adds optional global/default account typing to AppConfig
- Treats account data as optional (not all apps will need login)
- Only references account data when it is being used to log in; before it was announced with every feature check
- Removes check for account before auditing a route; if accounts are optional, no need for it to be set to run

Closes #64