### PR TITLE
Creates all-in-one CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,36 @@ Lumberjack's client:
 
 1.  Copy or rename the `./example.lsconfig.js` file so you have a `./.ljconfig.js` file. Then edit it to suit your application's needs. We recommend starting small with just a few routes to test your setup.
 
-1.  Run `yarn lumberjack` in the root directory. This will present some options. To begin, select `Generate a11y reports for routes`. At this point, Axe will crawl your routes and generate reports. Please note this can take some time for larger sites, but the terminal will keep you updated about progress as it runs.
+1. Run `yarn lumberjack` and select `Run full audit`. This will check every route on every feature, and combine any violations found into a unique violation report. Please note this can take some time for larger sites, but the terminal will keep you updated about progress as it runs.
 
-1.  Once that is complete, run `yarn lumberjack` again, and select `Combine and tally report data`. You'll be prompted with report IDs based on the date the report was run. Select the one you just ran, and summary reports will be generated.
+1. Once that completes successfully, you can start up the client locally to view the results by running `cd client && yarn start` from root. A browser window will open showing your dashboard. Happy testing!
 
-1.  Once those two tasks have been completed successfully, you can run the client to display the results by running `cd client && yarn start` from root. A browser window should open showing you your results. Happy testing!
+## Additional CLI Options
+
+### Running Individual Tasks
+
+There are two main tasks that need to run to provide the client with enough data to display:
+
+1. auditing all the routes and generating per-route reports, and
+1. generating unique violation data based on those reports
+
+You may find situations where running one or both individually are needed, so they can be run independently with the following:
+
+**If you need to generate unique violation data for a particular report ID:**
+1. Run `yarn lumberjack`.
+1. Select `Run individual tasks`.
+1. Select `Generate unique violation data`. You'll be prompted with report IDs based on the date the report was run.
+
+**If you need to run an audit on a specific feature or all features:**
+1. Run `yarn lumberjack`.
+1. Select `Run individual tasks`.
+1. select `Generate per-route feature reports`. 
+
+PLEASE NOTE: If you select this option you'll ALSO need to run `Generate unique violation data` after for that data to be available to the client.
+
+### Viewing an Audit Summary
+
+You can also quickly view the audit summary of any available report ID by running `yarn lumberjack` and selecting `Get audit summary for a report ID`.
 
 ## Versioning
 

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,4 +1,4 @@
-import inquirer from 'inquirer';
+import inquirer, { Answers } from 'inquirer';
 
 import config from '../.ljconfig';
 import { FeatureConfig } from '../lumberjack.types'
@@ -20,13 +20,21 @@ const featureList = config?.features?.map((feature: FeatureConfig) => {
   }
 }) || []
 
+const currentReportIds = getCurrentReportIds()
+
+const initialChoices = [
+  { name: 'Run full audit', value: 'full' },
+  { name: 'Run individual tasks', value: 'tasks' },
+]
+
+// If there are available Report IDs, let a user check their summaries.
+if (currentReportIds.length) {
+  initialChoices.push({ name: 'Get audit summary for a report ID', value: 'routes' })
+}
+
 const questions = [
   {
-    choices: [
-      { name: 'Run full audit', value: 'full' },
-      { name: 'Run individual tasks', value: 'tasks' },
-      { name: 'Get audit summary for a report ID', value: 'routes' },
-    ],
+    choices: initialChoices,
     message: 'What would you like to do?',
     name: 'run_scope',
     type: 'list',
@@ -39,7 +47,7 @@ const questions = [
       { name: 'Generate unique violation data', value: 'unique' },
       { name: 'Generate per-route feature reports', value: 'reports' },
     ],
-    when: (answers: any) => answers.run_scope === 'tasks',
+    when: (answers: Answers) => answers.run_scope === 'tasks',
   },
   {
     type: 'list',
@@ -52,21 +60,25 @@ const questions = [
         value: 'one',
       },
     ],
-    when: (answers: any) => answers.task === 'reports',
+    when: (answers: Answers) => answers.task === 'reports',
   },
   {
     type: 'list',
     name: 'report_id',
     message: 'Which report ID would you like to base this on?',
-    choices: getCurrentReportIds(),
-    when: (answers: any) => answers.task === 'unique' || answers.run_scope === 'routes',
+    choices: currentReportIds,
+    when: (answers: Answers) => (
+      currentReportIds.length
+      || answers.task === 'unique'
+      || answers.run_scope === 'routes'
+    ),
   },
   {
     type: 'list',
     name: 'features',
     message: 'Which feature would you like to check?',
     choices: featureList,
-    when: (answers: any) => answers.what_features === 'one',
+    when: (answers: Answers) => answers.what_features === 'one',
   },
   {
     type: 'checkbox',
@@ -82,7 +94,7 @@ const questions = [
         value: 'not-headless',
       },
     ],
-    when: (answers: any) => answers.run_scope === 'full' || answers.task === 'reports',
+    when: (answers: Answers) => answers.run_scope === 'full' || answers.task === 'reports',
   },
 ];
 

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,10 +1,10 @@
-import inquirer, { QuestionCollection } from 'inquirer'
+import inquirer from 'inquirer';
 
-import config from '../.ljconfig'
-
+import config from '../.ljconfig';
 import { FeatureConfig } from '../lumberjack.types'
 
 import { Audits } from './audits'
+import { REPORT_ID } from './_constants'
 import { Reports } from './reports'
 import { Violations } from './violations'
 import { getCurrentReportIds, isMissingRequiredConfig } from './settings'
@@ -13,8 +13,62 @@ const AuditUtilities = new Audits()
 const ReportUtilites = new Reports()
 const ViolationUtilities = new Violations()
 
-const runAudit = (): void => {
-  const settingsPrompt: QuestionCollection = {
+const featureList = config?.features?.map((feature: FeatureConfig) => {
+  return {
+    name: feature.name,
+    value: [feature],
+  }
+}) || []
+
+const questions = [
+  {
+    choices: [
+      { name: 'Run full audit', value: 'full' },
+      { name: 'Run individual tasks', value: 'tasks' },
+      { name: 'Get audit summary for a report ID', value: 'routes' },
+    ],
+    message: 'What would you like to do?',
+    name: 'run_scope',
+    type: 'list',
+  },
+  {
+    type: 'list',
+    name: 'task',
+    message: 'What task would you like to run?',
+    choices: [
+      { name: 'Generate unique violation data', value: 'unique' },
+      { name: 'Generate per-route feature reports', value: 'reports' },
+    ],
+    when: (answers: any) => answers.run_scope === 'tasks',
+  },
+  {
+    type: 'list',
+    name: 'what_features',
+    message: 'How many features would you like to check?',
+    choices: [
+      { name: 'All features', value: 'all' },
+      {
+        name: 'A single feature',
+        value: 'one',
+      },
+    ],
+    when: (answers: any) => answers.task === 'reports',
+  },
+  {
+    type: 'list',
+    name: 'report_id',
+    message: 'Which report ID would you like to base this on?',
+    choices: getCurrentReportIds(),
+    when: (answers: any) => answers.task === 'unique' || answers.run_scope === 'routes',
+  },
+  {
+    type: 'list',
+    name: 'features',
+    message: 'Which feature would you like to check?',
+    choices: featureList,
+    when: (answers: any) => answers.what_features === 'one',
+  },
+  {
     type: 'checkbox',
     name: 'settings',
     message: 'Would you like to include any of the following in this run?',
@@ -28,119 +82,43 @@ const runAudit = (): void => {
         value: 'not-headless',
       },
     ],
+    when: (answers: any) => answers.run_scope === 'full' || answers.task === 'reports',
+  },
+];
+
+export const CLI = async (): Promise<void> => {
+
+  if (isMissingRequiredConfig()) {
+    return
   }
 
-  inquirer
-    .prompt([
-      {
-        type: 'list',
-        name: 'check',
-        message: 'What would you like to do?',
-        choices: [
-          { name: 'Check for a11y violations on all features', value: 'all' },
-          {
-            name: 'Check for a11y violations on a single feature',
-            value: 'one',
-          },
-        ],
-      },
-    ])
-    .then(({ check }) => {
-      if (check === 'one') {
-        const featureList = config.features.map((feature: FeatureConfig) => {
-          return {
-            name: feature.name,
-            value: [feature],
-          }
-        })
+  const answers = await inquirer.prompt(questions);
+  const { features, report_id, run_scope, settings, task } = answers;
 
-        return inquirer.prompt([
-          {
-            type: 'list',
-            name: 'features',
-            message: 'Which feature would you like to check?',
-            choices: featureList,
-          },
-          settingsPrompt,
-        ])
-      } else {
-        return inquirer.prompt(settingsPrompt)
-      }
-    })
-    .then(answers => {
-      if (!answers.features) {
-        answers.features = config.features
-      }
+  if (run_scope === 'routes' && report_id) {
+    ViolationUtilities.getRouteData(report_id)
+  }
 
-      const notHeadless = !!answers.settings.includes('not-headless')
+  if (run_scope === 'full' || task === 'reports') {
 
-      AuditUtilities.runAudit(
-        answers.features,
-        !notHeadless,
-        answers.settings.includes('screenshot')
-      )
-    })
-}
+    const featuresToCheck = features ?? config.features
+    const notHeadless = !!settings.includes('not-headless')
 
-const runCombine = (): void => {
-  inquirer
-    .prompt([
-      {
-        type: 'list',
-        name: 'reportId',
-        message: 'Which report ID would you like to combine data for?',
-        choices: getCurrentReportIds(),
-      },
-    ]).then((answer) => {
-      ReportUtilites.createAllReports(answer.reportId)
-    })
-}
+    await AuditUtilities.runAudit(
+      featuresToCheck,
+      !notHeadless,
+      settings.includes('screenshot')
+    )
+  }
 
-const runGetRouteData = (): void => {
-  inquirer
-    .prompt([
-      {
-        type: 'list',
-        name: 'reportId',
-        message: 'Which report ID would you like route data for?',
-        choices: getCurrentReportIds(),
-      },
-    ]).then((answer) => {
-      ViolationUtilities.getRouteData(answer.reportId)
-    })
-}
+  if (run_scope === 'full' || task === 'unique') {
 
-if (isMissingRequiredConfig()) {
-  process.exit()
-}
+    const currentReportId = report_id ?? REPORT_ID
 
-inquirer
-  .prompt([
-    {
-      type: 'list',
-      name: 'action',
-      message: 'What would you like to do?',
-      choices: [
-        { name: 'Generate a11y reports for routes', value: 'audit' },
-        { name: 'Combine and tally report data', value: 'combine' },
-        { name: 'Review application route info', value: 'routes' },
-      ],
-    },
-  ])
-  .then(choice => {
-    const { action } = choice
+    console.group(`Creating unique violation reports for ${currentReportId}...`)
+    await ReportUtilites.createAllReports(currentReportId);
+    console.groupEnd()
+  }
+};
 
-    switch (action) {
-      case 'audit':
-        runAudit()
-        break
-      case 'combine':
-        runCombine()
-        break
-      case 'routes':
-        runGetRouteData()
-        break
-      default:
-        console.log('Action not found, something went wrong')
-    }
-  })
+CLI();

--- a/utils/settings.ts
+++ b/utils/settings.ts
@@ -49,20 +49,27 @@ export const isMissingRequiredConfig = (): boolean => {
    * @returns {string[]}
    */
 export const getCurrentReportIds = (): string[] => {
-  const filenames = fs.readdirSync(`${AUDIT_FOLDER}/route-reports`)
+
+  const reportsPath = `${AUDIT_FOLDER}/route-reports`
   const reportIds: string[] = []
-  // fetch all json files
-  for (const filename of filenames) {
-    const file = fs.readFileSync(
-      `${AUDIT_FOLDER}/route-reports/${filename}`,
-      'utf8'
-    )
-    const data = JSON.parse(file)
-    data.forEach((entry: RouteReport) => {
-      if (!reportIds.includes(entry.reportId)) {
-        reportIds.push(entry.reportId)
-      }
-    })
+
+  if (fs.existsSync(reportsPath)) {
+
+    const filenames = fs.readdirSync(reportsPath)
+
+    // fetch all json files
+    for (const filename of filenames) {
+      const file = fs.readFileSync(
+        `${AUDIT_FOLDER}/route-reports/${filename}`,
+        'utf8'
+      )
+      const data = JSON.parse(file)
+      data.forEach((entry: RouteReport) => {
+        if (!reportIds.includes(entry.reportId)) {
+          reportIds.push(entry.reportId)
+        }
+      })
+    }
   }
 
   return reportIds


### PR DESCRIPTION
**Background / Why are these changes being added:**

Currently, a user needs to select the `Generate a11y reports for routes` option and let things run, and THEN remember to run lumberjack again and select the `Combine and tally report data` option. Without both of these steps, the client wouldn't render properly, and it might not be immediately clear what went wrong. This could cause a frustrating experience.

**Changes introduced:**

* CLI updated with `Run full audit` option that both crawls all features and routes AND generates unique violation data in one step
* A user can still run each task individually as well if they need to
* Some CLI options have been reworded for clarity
* README updated to reflect new options