### PR TITLE
[Bugfix]: Adds additional token to release script

### DIFF
--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -43,8 +43,6 @@ jobs:
   steps:
   - name: Checkout
     uses: actions/checkout@v2
-    with:
-      persist-credentials: false
 
   - name: Setup Node.js
     uses: actions/setup-node@v1
@@ -57,4 +55,5 @@ jobs:
   - name: Release
     run: npx semantic-release
     env:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adjusts release job to include additional token [based on the discussion here](https://github.com/semantic-release/github/issues/175); hoping this gets around approval error we're seeing on these jobs currently.