### PR TITLE
[Bugfix]: CLI asks for report ID for full audit task

### DIFF
--- a/utils/index.ts
+++ b/utils/index.ts
@@ -68,9 +68,8 @@ const questions = [
     message: 'Which report ID would you like to base this on?',
     choices: currentReportIds,
     when: (answers: Answers) => (
-      currentReportIds.length
-      || answers.task === 'unique'
-      || answers.run_scope === 'routes'
+      answers.run_scope !== 'full'
+      && currentReportIds.length
     ),
   },
   {


### PR DESCRIPTION
**Issue fixed:**
When a user selected the Full Audit task from the CLI, the user was being prompted to select a report ID. A full audit will create a new report ID, so the user should not be prompted to select one.

**Changes introduced:**
- Updates check used to determine if user should be prompted to select an ID to run on. 